### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Awesome Flux2 CRDs repository
 
 This repository contains CRDs from popular operators for Kubernetes installed via Flux2. All CRDs are moved to this repository because Flux2 cannot install a product and custom resource if the CRD is not yet available.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
 
 ## Support Project
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/N4N011QV6F)


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*